### PR TITLE
token issue fixed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.9
+    rev: v0.15.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
       - id: check-yaml
@@ -21,7 +21,7 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+        exclude: ^CHANGELOG\.md$
 
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ default_bump_level = 0
 [tool.semantic_release.remote]
 name = "origin"
 type = "github"
-token = "GH_TOKEN"
+token = { env = "GH_TOKEN" }
 
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]


### PR DESCRIPTION
the fix. token = "GH_TOKEN" was passing the literal string as the token, causing the 401. token = { env = "GH_TOKEN" } tells semantic-release to read it from the GH_TOKEN environment variable that your workflow already sets correctly.
